### PR TITLE
Pass peripheral ID along with events

### DIFF
--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -29,23 +29,23 @@ class Scanner extends EventEmitter {
     switch (eventType) {
       case Parser.TEMPERATURE_EVENT: {
         const { temperature } = event;
-        this.emit('temperatureChange', temperature);
+        this.emit('temperatureChange', temperature, peripheral.id);
         break;
       }
       case Parser.HUMIDITY_EVENT: {
         const { humidity } = event;
-        this.emit('humidityChange', humidity);
+        this.emit('humidityChange', humidity, peripheral.id);
         break;
       }
       case Parser.BATTERY_EVENT: {
         const { battery } = event;
-        this.emit('batteryChange', battery);
+        this.emit('batteryChange', battery, peripheral.id);
         break;
       }
       case Parser.TEMPERATURE_AND_HUMIDITY_EVENT: {
         const { temperature, humidity } = event;
-        this.emit('temperatureChange', temperature);
-        this.emit('humidityChange', humidity);
+        this.emit('temperatureChange', temperature, peripheral.id);
+        this.emit('humidityChange', humidity, peripheral.id);
         break;
       }
       default: {


### PR DESCRIPTION
Nice work here, I have used your scanned elsewhere but I need the device ID to be passed back with events.

Sending it as another parameter should make the scanner a lot more re-usable. Unless you have a better idea?