### PR TITLE
Remove Node.js 7, add 10 and 11 (node)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ os:
 language: node_js
 node_js:
   - 6
-  - 7
   - 8
+  - 10
+  - node
 install:
   - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ node_js:
   - 8
   - 10
   - node
+ matrix:
+   allow_failures:
+     - node_js: 10
+     - node_js: node
 install:
   - npm install
 script:


### PR DESCRIPTION
Node.js `7` is out of support, `10` and `node` are the last stable long term support and the last stable versions.