### PR TITLE
adjusted minimum value for temp sensor

### DIFF
--- a/lib/accessory.js
+++ b/lib/accessory.js
@@ -355,7 +355,7 @@ class HygrothermographAccessory {
       .on("get", this.onCharacteristicGetValue.bind(this, "temperature"));
     temperatureService
       .getCharacteristic(Characteristic.CurrentTemperature)
-      .setProps({ minValue: -10 });
+      .setProps({ minValue: -40 });
     temperatureService
       .getCharacteristic(Characteristic.CurrentTemperature)
       .setProps({ maxValue: 60 });


### PR DESCRIPTION
I tested the LYWSD03MMC on my balcony in Quebec. It works well below -25C. The temperature is correctly reported in the detailed readings for Eve, but the temperature would not go below -10C in HomeKit and HomeBridge was complaining about the fact that the temperature was below the set minimum. I adjusted the minimum and I tested it in this frigid night.  HomeKit is correctly reporting -18C right now :-)