### PR TITLE
Add AirQuality Service to Hygrotermograph

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -38,6 +38,15 @@
         "placeholder": "e.g. 00:00:00:00:00:00",
         "description": "Optional. Specify when running multiple devices"
       },
+      "airQualityName": {
+        "title": "Air Quality Name",
+        "type": "string",
+        "format": "string",
+        "default": "AirQuality",
+        "condition": {
+          "functionBody": "return ['Hygrotermograph'].includes(model.type);"
+        }
+      },
       "temperatureName": {
         "title": "Temperature",
         "type": "string",
@@ -248,6 +257,7 @@
       "title": "<strong>Custom Name</strong>",
       "flex-flow": "column wrap",
       "items": [
+        "airQualityName",
         "temperatureName",
         "humidityName",
         "moistureName",

--- a/lib/accessory.js
+++ b/lib/accessory.js
@@ -52,6 +52,7 @@ class HygrothermographAccessory {
       default:
         throw Error(`Unsupported accessory type "${this.type}"`);
     }
+    this.airQualityService = this.getAirQualityService();
     this.informationService = this.getInformationService();
     this.batteryService = this.getBatteryService();
     this.fakeGatoHistoryService = this.getFakeGatoHistoryService();
@@ -62,6 +63,11 @@ class HygrothermographAccessory {
     this.scanner = this.setupScanner();
 
     this.log.debug(`Initialized accessory of type ${this.type}`);
+  }
+
+  get airQuality() {
+    // placeholder for future implementation
+    return Characteristic.AirQuality.EXCELLENT;
   }
 
   setTemperature(newValue, force = false) {
@@ -205,6 +211,10 @@ class HygrothermographAccessory {
         .updateValue(newValue);
     }
     this.publishValueToMQTT(this.batteryMQTTTopic, this.batteryLevel);
+  }
+
+  get airQualityName() {
+    return this.config.airQualityName || "AirQuality";
   }
 
   get batteryLevel() {
@@ -560,6 +570,16 @@ class HygrothermographAccessory {
     }
   }
 
+  getAirQualityService() {
+    const airQualityService = new Service.AirQualitySensor(
+      this.airQualityName
+      );
+    airQualityService
+      .getCharacteristic(Characteristic.AirQuality)
+      .on("get", this.onCharacteristicGetValue.bind(this, "airQuality"));
+    return airQualityService;
+  }
+
   getTemperatureService() {
     const temperatureService = new Service.TemperatureSensor(
       this.temperatureName
@@ -637,7 +657,7 @@ class HygrothermographAccessory {
     ];
     switch (this.type) {
       case AccessoryType.Hygrotermograph:
-        services.push(this.temperatureService, this.humidityService);
+        services.push(this.airQualityService, this.temperatureService, this.humidityService);
         break;
       case AccessoryType.MiFlora:
         services.push(


### PR DESCRIPTION
After updating Eve App to version 6, I lost all LYWSD03MMC sensors in app. I noticed, that if I will add a AirQuality Service, sensors are back.

This is how it looks after the changes:
![screenshoot](https://github.com/hannseman/homebridge-mi-hygrothermograph/assets/84290812/37ddb2c5-f952-4c17-9dae-ef49d0f7a3fc)

